### PR TITLE
Added short names for useful arguments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ if your environment is such as below. ::
 ``--installed`` option
 ----------------------------------------
 
-``--installed`` option with ``ppic`` then collect all information in your in environment. ::
+``--installed`` (or ``-i``) option with ``ppic`` then collect all information in your in environment. ::
 
 
   $ ppic --installed
@@ -44,7 +44,7 @@ if your environment is such as below. ::
 ``--stable-only`` option
 ----------------------------------------
 
-``--stable-only`` option with ``ppic`` then collecting stable version only(but this is heuristic aproach maybe wrong, maybe)
+``--stable-only`` (or ``-s``) option with ``ppic`` then collecting stable version only(but this is heuristic aproach maybe wrong, maybe)
 
 ::
 
@@ -82,7 +82,7 @@ if your environment is such as below. ::
 ``--dependency`` option
 ----------------------------------------
 
-``--dependency`` option with ``ppic`` then, collecting information in consideration of package dependency, so including dependents packages.
+``--dependency`` (or ``-d``) option with ``ppic`` then, collecting information in consideration of package dependency, so including dependents packages.
 
 ::
 

--- a/ppic/__init__.py
+++ b/ppic/__init__.py
@@ -173,9 +173,9 @@ class RequestRepository(object):
 def parse(args):
     parser = argparse.ArgumentParser()
     parser.add_argument('--all', action="store_true", help="(deprecated) same as --installed")  # deprecated
-    parser.add_argument('--installed', action="store_true", help="collecting installed packages information in your env")
-    parser.add_argument('--dependency', action="store_true", help="collecting dependents package's information")
-    parser.add_argument('--stable-only', action="store_true", help="newest stable version(guessing)")
+    parser.add_argument('-i', '--installed', action="store_true", help="collecting installed packages information in your env")
+    parser.add_argument('-d', '--dependency', action="store_true", help="collecting dependents package's information")
+    parser.add_argument('-s', '--stable-only', action="store_true", help="newest stable version(guessing)")
     parser.add_argument('--no-cache', action="store_true", help="doesn't using temporary cache(timeout default is 10min)")
     parser.add_argument('--cache-timeout', default=default_options.cache_timeout, type=int, help="temporary cache timeout(seconds)")
     parser.add_argument('--logging', choices=["debug", "info"], default=None, help="activation for logging message")


### PR DESCRIPTION
Added shoart names for useful arguments. 
I often use ppic with `installed` and `stable-only` arguments. 
but it supports only long name. it's hard to type repeatedly. 

so now it supports short name for three commonly used arguments.
- installed
- stable-only
- dependencies

Anyway there isn't `0.2.5` version of `ppic`. 
If it published on GitHub, I'll run tests (and fix if necessary) and wait for review. 
